### PR TITLE
Add a `channel_from_std` API

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,7 @@
 use serde_::{Deserialize, Serialize};
 use std::env;
 use std::process;
-use tokio_unix_ipc::{channel, Bootstrapper, Receiver, Sender};
+use tokio_unix_ipc::{symmetric_channel, Bootstrapper, Receiver, Sender};
 
 const ENV_VAR: &str = "PROC_CONNECT_TO";
 
@@ -32,14 +32,14 @@ async fn main() {
             .spawn()
             .unwrap();
 
-        let (tx, rx) = channel().unwrap();
+        let (tx, rx) = symmetric_channel().unwrap();
         bootstrapper
             .send(Task::Sum(vec![23, 42], tx))
             .await
             .unwrap();
         println!("result: {}", rx.recv().await.unwrap());
 
-        let (tx, rx) = channel().unwrap();
+        let (tx, rx) = symmetric_channel().unwrap();
         bootstrapper
             .send(Task::Sum((0..10).collect(), tx))
             .await

--- a/src/raw_channel.rs
+++ b/src/raw_channel.rs
@@ -290,6 +290,15 @@ pub fn raw_channel() -> io::Result<(RawSender, RawReceiver)> {
     ))
 }
 
+/// Creates a raw connected channel from an already extant socket.
+pub fn raw_channel_from_std(sender: UnixStream) -> io::Result<(RawSender, RawReceiver)> {
+    let receiver = sender.try_clone()?;
+    Ok((
+        RawSender::from_std(sender)?,
+        RawReceiver::from_std(receiver)?,
+    ))
+}
+
 /// An async raw receiver.
 #[derive(Debug)]
 pub struct RawReceiver {

--- a/src/typed_channel.rs
+++ b/src/typed_channel.rs
@@ -97,7 +97,16 @@ fd_impl!(raw_receiver, RawReceiver, Receiver<T>);
 fd_impl!(raw_sender, RawSender, Sender<T>);
 
 /// Creates a typed connected channel.
-pub fn channel<T: Serialize + DeserializeOwned>() -> io::Result<(Sender<T>, Receiver<T>)> {
+pub fn channel<S: Serialize + DeserializeOwned, R: Serialize + DeserializeOwned>(
+) -> io::Result<(Sender<S>, Receiver<R>)> {
+    let (sender, receiver) = raw_channel()?;
+    Ok((sender.into(), receiver.into()))
+}
+
+/// Creates a typed connected channel where the same type is
+/// both sent and received.
+pub fn symmetric_channel<T: Serialize + DeserializeOwned>() -> io::Result<(Sender<T>, Receiver<T>)>
+{
     let (sender, receiver) = raw_channel()?;
     Ok((sender.into(), receiver.into()))
 }

--- a/src/typed_channel.rs
+++ b/src/typed_channel.rs
@@ -102,6 +102,16 @@ pub fn channel<T: Serialize + DeserializeOwned>() -> io::Result<(Sender<T>, Rece
     Ok((sender.into(), receiver.into()))
 }
 
+/// Creates a typed connected channel from an already extant socket.
+pub fn channel_from_std<S: Serialize + DeserializeOwned, R: Serialize + DeserializeOwned>(
+    sender: UnixStream,
+) -> io::Result<(Sender<S>, Receiver<R>)> {
+    let receiver = sender.try_clone()?;
+    let sender = RawSender::from_std(sender)?;
+    let receiver = RawReceiver::from_std(receiver)?;
+    Ok((sender.into(), receiver.into()))
+}
+
 impl<T: Serialize + DeserializeOwned> Receiver<T> {
     /// Connects a receiver to a named unix socket.
     pub async fn connect<P: AsRef<Path>>(p: P) -> io::Result<Receiver<T>> {

--- a/tests/test_bootstrap.rs
+++ b/tests/test_bootstrap.rs
@@ -1,4 +1,4 @@
-use tokio_unix_ipc::{channel, Bootstrapper, Receiver, Sender};
+use tokio_unix_ipc::{symmetric_channel, Bootstrapper, Receiver, Sender};
 
 #[tokio::test]
 async fn test_bootstrap() {
@@ -22,7 +22,7 @@ async fn test_bootstrap() {
 async fn test_bootstrap_reverse() {
     let bootstrapper = Bootstrapper::new().unwrap();
     let path = bootstrapper.path().to_owned();
-    let (tx, rx) = channel::<u32>().unwrap();
+    let (tx, rx) = symmetric_channel::<u32>().unwrap();
 
     tokio::spawn(async move {
         let receiver = Receiver::<Sender<u32>>::connect(path).await.unwrap();


### PR DESCRIPTION
Add a `channel_from_std` API

This is more obvious to use from e.g. systemd socket activation,
where we're passed a socket allocated outside the current process.

---

typed_channel: Make `channel` asymmetric, add `symmetric_channel`

To better handle the general case of asymmetric protocols.

I originally tried to just change `channel()` but it caused a lot
of pain in type inference in the test suite.  Change
most of the tests to use a `symmetric_channel()` as a convenient shorthand,
with one new test for an asymmetric `channel()`.

---

