### PR TITLE
switch to tokio mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ panic-support = ["serde"]
 [dependencies]
 libc = "0.2.67"
 nix = "0.24.0"
-tokio = { version = "1.8.2", features = ["net"] }
+tokio = { version = "1.8.2", features = ["net", "sync"] }
 serde_ = { package = "serde", version = "1.0.104", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 rand = { version = "0.8.0", optional = true }


### PR DESCRIPTION
This change lets `bootstrapper.send` be used in `async` functions.