### PR TITLE
fix build & clippy lints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.53.0
-          profile: minimal
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Test
         run: cargo check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-unix-ipc"
 version = "0.3.0"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "A minimal abstraction for IPC via unix sockets."
 homepage = "https://github.com/mitsuhiko/tokio-unix-ipc"

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -24,7 +24,7 @@ use serde_::{de, ser};
 use serde_::{de::DeserializeOwned, Deserialize, Serialize};
 
 thread_local! {
-    static IPC_FDS: RefCell<Vec<Vec<RawFd>>> = RefCell::new(Vec::new());
+    static IPC_FDS: RefCell<Vec<Vec<RawFd>>> = const {RefCell::new(Vec::new())};
 }
 
 /// Can transfer a unix file handle across processes.
@@ -282,7 +282,7 @@ mod structural {
             let msgpack = Vec::<u8>::deserialize(deserializer)
                 .map_err(|e| de::Error::custom(e.to_string()))?;
             Ok(Structural(
-                rmp_serde::from_read_ref(&msgpack).map_err(|e| de::Error::custom(e.to_string()))?,
+                rmp_serde::from_slice(&msgpack).map_err(|e| de::Error::custom(e.to_string()))?,
             ))
         }
     }

--- a/tests/test_typed_channel.rs
+++ b/tests/test_typed_channel.rs
@@ -90,7 +90,7 @@ async fn test_conversion() {
     });
 
     let b = tokio::spawn(async move {
-        assert_eq!(rx.recv().await.unwrap(), true);
+        assert!(rx.recv().await.unwrap());
     });
 
     a.await.unwrap();


### PR DESCRIPTION
This will fix the build: 
- updated Cargo rust edition to 2021
- fix a bunch of clippy lints
- use https://github.com/dtolnay/rust-toolchain for Rust toolchain in Github actions as the one in use has since been deprecated. 