### PR TITLE
Use io::ErrorKind::InvalidData for (de)serialization errors

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -155,7 +155,7 @@ pub fn is_ipc_mode() -> bool {
 fn bincode_to_io_error(err: bincode::Error) -> io::Error {
     match *err {
         bincode::ErrorKind::Io(err) => err,
-        err => io::Error::new(io::ErrorKind::Other, err.to_string()),
+        err => io::Error::new(io::ErrorKind::InvalidData, err.to_string()),
     }
 }
 


### PR DESCRIPTION
This way the caller of Receiver::recv() can distinguish between a broken connection and receiving garbage data.

https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.InvalidData