### PR TITLE
Overhaul FD handling/ownership

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-unix-ipc"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A minimal abstraction for IPC via unix sockets."
@@ -10,7 +10,7 @@ keywords = ["ipc", "unix-socket", "subprocess"]
 readme = "README.md"
 autoexamples = true
 autotests = true
-rust-version = "1.60"
+rust-version = "1.66"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io;
-use std::os::unix::prelude::RawFd;
+use std::os::fd::BorrowedFd;
 use std::path::{Path, PathBuf};
 use tokio::sync::Mutex;
 
@@ -62,7 +62,7 @@ impl Bootstrapper {
     /// This can be called multiple times to send more than one value
     /// into the inner socket. On the other side a
     /// [`RawReceiver`](crate::RawReceiver) must be used.
-    pub async fn send_raw(&self, data: &[u8], fds: &[RawFd]) -> io::Result<usize> {
+    pub async fn send_raw(&self, data: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<usize> {
         if self.sender.lock().await.is_none() {
             let (sock, _) = self.listener.accept().await?;
             let sender = RawSender::from_std(sock.into_std()?)?;
@@ -87,7 +87,8 @@ impl Bootstrapper {
     ) -> io::Result<()> {
         // replicate the logic from the typed sender with the dummy
         // bool here.
-        let (bytes, fds) = crate::serde::serialize((data, true))?;
+        let to_send = (data, true);
+        let (bytes, fds) = crate::serde::serialize(&to_send)?;
         self.send_raw(&bytes, &fds).await.map(|_| ())
     }
 }

--- a/src/raw_channel.rs
+++ b/src/raw_channel.rs
@@ -1,17 +1,15 @@
 use std::io;
 use std::io::{IoSlice, IoSliceMut};
 use std::mem;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::slice;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use nix::errno::Errno;
 use nix::sys::socket::{
     c_uint, recvmsg, sendmsg, ControlMessage, ControlMessageOwned, MsgFlags, CMSG_SPACE,
 };
-use nix::unistd;
 
 use tokio::io::unix::AsyncFd;
 
@@ -91,8 +89,7 @@ macro_rules! fd_impl {
         impl $ty {
             pub(crate) unsafe fn from_raw_fd(fd: RawFd) -> io::Result<Self> {
                 Ok(Self {
-                    inner: AsyncFd::new(fd)?,
-                    dead: AtomicBool::new(false),
+                    inner: AsyncFd::new(unsafe { OwnedFd::from_raw_fd(fd) })?,
                 })
             }
 
@@ -105,42 +102,36 @@ macro_rules! fd_impl {
             /// This function panics if it is not called from within a runtime with
             /// IO enabled.
             pub fn from_std(stream: UnixStream) -> io::Result<Self> {
-                unsafe { Self::from_raw_fd(stream.into_raw_fd()) }
+                Ok(Self {
+                    inner: AsyncFd::new(OwnedFd::from(stream))?,
+                })
             }
+        }
 
-            pub(crate) fn extract_raw_fd(&self) -> RawFd {
-                if self.dead.swap(true, Ordering::SeqCst) {
-                    panic!("handle was moved previously");
-                } else {
-                    self.inner.as_raw_fd()
+        impl From<OwnedFd> for $ty {
+            fn from(fd: OwnedFd) -> Self {
+                Self {
+                    inner: AsyncFd::new(fd)
+                        .expect("conversion from OwnedFd requires an active tokio runtime"),
                 }
             }
         }
 
-        impl FromRawFd for $ty {
-            unsafe fn from_raw_fd(fd: RawFd) -> Self {
-                Self::from_raw_fd(fd)
-                    .expect("conversion from RawFd requires an active tokio runtime")
+        impl From<$ty> for OwnedFd {
+            fn from(val: $ty) -> OwnedFd {
+                val.inner.into_inner()
             }
         }
 
-        impl IntoRawFd for $ty {
-            fn into_raw_fd(self) -> RawFd {
-                self.extract_raw_fd()
+        impl AsFd for $ty {
+            fn as_fd(&self) -> BorrowedFd<'_> {
+                unsafe { BorrowedFd::borrow_raw(self.inner.as_raw_fd()) }
             }
         }
 
         impl AsRawFd for $ty {
             fn as_raw_fd(&self) -> RawFd {
                 self.inner.as_raw_fd()
-            }
-        }
-
-        impl Drop for $ty {
-            fn drop(&mut self) {
-                if !self.dead.load(Ordering::SeqCst) {
-                    unistd::close(self.as_raw_fd()).ok();
-                }
             }
         }
     };
@@ -163,20 +154,21 @@ macro_rules! nix_eintr {
 fn recv_impl(
     fd: RawFd,
     buf: &mut [u8],
-    fds: Option<Vec<i32>>,
+    fds: &mut Vec<OwnedFd>,
     fd_count: usize,
     _want_creds: bool,
-) -> io::Result<(usize, Option<Vec<RawFd>>, Option<Credentials>)> {
+) -> io::Result<(usize, Option<Credentials>)> {
     let mut iov = [IoSliceMut::new(buf)];
-    let mut new_fds = None;
 
     #[allow(unused_mut)]
     let mut creds = None;
 
     // Compute the size of ancillary data, combining expected number of file descriptors
-    // with any space needed for credentials.
+    // with any space needed for credentials.  Subtract already-accumulated fds so the
+    // cmsg buffer shrinks appropriately on retries.
     let msgspace_size = {
-        let fd_size = unsafe { CMSG_SPACE(mem::size_of::<RawFd>() as c_uint) * fd_count as u32 };
+        let remaining = fd_count.saturating_sub(fds.len());
+        let fd_size = unsafe { CMSG_SPACE(mem::size_of::<RawFd>() as c_uint) * remaining as u32 };
         #[cfg(any(target_os = "android", target_os = "linux"))]
         {
             let cred_size: u32 = _want_creds
@@ -195,19 +187,25 @@ fn recv_impl(
 
     let msg = nix_eintr!(recvmsg::<()>(fd, &mut iov, Some(&mut cmsgspace), MSG_FLAGS))?;
 
+    let mut received_fds = false;
     for cmsg in msg.cmsgs() {
         match cmsg {
-            ControlMessageOwned::ScmRights(fds) => {
-                if !fds.is_empty() {
+            ControlMessageOwned::ScmRights(new_fds) => {
+                if !new_fds.is_empty() {
                     #[cfg(target_os = "macos")]
                     unsafe {
-                        for &fd in &fds {
+                        for &fd in &new_fds {
                             // as per documentation this does not ever fail
                             // with EINTR
                             libc::ioctl(fd, libc::FIOCLEX);
                         }
                     }
-                    new_fds = Some(fds);
+                    fds.extend(
+                        new_fds
+                            .into_iter()
+                            .map(|fd| unsafe { OwnedFd::from_raw_fd(fd) }),
+                    );
+                    received_fds = true;
                 }
             }
             #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -218,23 +216,14 @@ fn recv_impl(
         }
     }
 
-    if msg.bytes == 0 {
+    if msg.bytes == 0 && !received_fds {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
             "could not read",
         ));
     }
 
-    let fds = match (fds, new_fds) {
-        (None, Some(new)) => Some(new),
-        (Some(mut old), Some(new)) => {
-            old.extend(new);
-            Some(old)
-        }
-        (old, None) => old,
-    };
-
-    Ok((msg.bytes, fds, creds))
+    Ok((msg.bytes, creds))
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -309,8 +298,7 @@ pub fn raw_channel_from_std(sender: UnixStream) -> io::Result<(RawSender, RawRec
 /// An async raw receiver.
 #[derive(Debug)]
 pub struct RawReceiver {
-    inner: AsyncFd<RawFd>,
-    dead: AtomicBool,
+    inner: AsyncFd<OwnedFd>,
 }
 
 impl RawReceiver {
@@ -321,7 +309,7 @@ impl RawReceiver {
     }
 
     /// Receives raw bytes from the socket.
-    pub async fn recv(&self) -> io::Result<(Vec<u8>, Option<Vec<RawFd>>)> {
+    pub async fn recv(&self) -> io::Result<(Vec<u8>, Vec<OwnedFd>)> {
         let mut header = MsgHeader::default();
         self.recv_impl(header.as_buf_mut(), 0, false).await?;
         let mut buf = header.make_buffer();
@@ -333,9 +321,7 @@ impl RawReceiver {
 
     /// Receives raw bytes and credentials from the socket.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    pub async fn recv_with_credentials(
-        &self,
-    ) -> io::Result<(Vec<u8>, Option<Vec<RawFd>>, Credentials)> {
+    pub async fn recv_with_credentials(&self) -> io::Result<(Vec<u8>, Vec<OwnedFd>, Credentials)> {
         nix::sys::socket::setsockopt(
             self.inner.as_raw_fd(),
             nix::sys::socket::sockopt::PassCred,
@@ -361,17 +347,18 @@ impl RawReceiver {
         buf: &mut [u8],
         fd_count: usize,
         want_creds: bool,
-    ) -> io::Result<(usize, Option<Vec<RawFd>>, Option<Credentials>)> {
+    ) -> io::Result<(usize, Vec<OwnedFd>, Option<Credentials>)> {
         let mut pos = 0;
-        let mut fds = None;
+        let mut fds = Vec::new();
+        let mut last_creds = None;
 
         loop {
             let mut guard = self.inner.readable().await?;
-            let (bytes, new_fds, creds) = match guard.try_io(|inner| {
+            let (bytes, creds) = match guard.try_io(|inner| {
                 recv_impl(
                     inner.as_raw_fd(),
                     &mut buf[pos..],
-                    fds.take(),
+                    &mut fds,
                     fd_count,
                     want_creds,
                 )
@@ -380,10 +367,12 @@ impl RawReceiver {
                 Err(_would_block) => continue,
             }?;
 
-            fds = new_fds;
+            if creds.is_some() {
+                last_creds = creds;
+            }
             pos += bytes;
-            if pos >= buf.len() {
-                return Ok((pos, fds, creds));
+            if pos >= buf.len() && fds.len() >= fd_count {
+                return Ok((pos, fds, last_creds));
             }
         }
     }
@@ -395,14 +384,12 @@ unsafe impl Sync for RawReceiver {}
 /// An async raw sender.
 #[derive(Debug)]
 pub struct RawSender {
-    inner: AsyncFd<RawFd>,
-    #[allow(dead_code)]
-    dead: AtomicBool,
+    inner: AsyncFd<OwnedFd>,
 }
 
 impl RawSender {
     /// Sends raw bytes and fds.
-    pub async fn send(&self, data: &[u8], fds: &[RawFd]) -> io::Result<usize> {
+    pub async fn send(&self, data: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<usize> {
         let header = MsgHeader {
             payload_len: data.len() as u32,
             fd_count: fds.len() as u32,
@@ -413,7 +400,11 @@ impl RawSender {
 
     /// Sends raw bytes and fds along with current process credentials.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    pub async fn send_with_credentials(&self, data: &[u8], fds: &[RawFd]) -> io::Result<usize> {
+    pub async fn send_with_credentials(
+        &self,
+        data: &[u8],
+        fds: &[BorrowedFd<'_>],
+    ) -> io::Result<usize> {
         let header = MsgHeader {
             payload_len: data.len() as u32,
             fd_count: fds.len() as u32,
@@ -422,18 +413,27 @@ impl RawSender {
         self.send_impl(data, fds, false).await
     }
 
-    async fn send_impl(&self, data: &[u8], mut fds: &[RawFd], creds: bool) -> io::Result<usize> {
+    async fn send_impl(
+        &self,
+        data: &[u8],
+        fds: &[BorrowedFd<'_>],
+        creds: bool,
+    ) -> io::Result<usize> {
+        // SAFETY: BorrowedFd is #[repr(transparent)] over RawFd
+        let raw_fds: &[RawFd] =
+            unsafe { slice::from_raw_parts(fds.as_ptr() as *const RawFd, fds.len()) };
         let mut pos = 0;
+        let mut send_fds = raw_fds;
         loop {
             let mut guard = self.inner.writable().await?;
             let sent = match guard
-                .try_io(|inner| send_impl(inner.as_raw_fd(), &data[pos..], fds, creds))
+                .try_io(|inner| send_impl(inner.as_raw_fd(), &data[pos..], send_fds, creds))
             {
                 Ok(result) => result,
                 Err(_would_block) => continue,
             }?;
             pos += sent;
-            fds = &[][..];
+            send_fds = &[][..];
             if pos >= data.len() {
                 return Ok(pos);
             }

--- a/src/raw_channel.rs
+++ b/src/raw_channel.rs
@@ -186,6 +186,11 @@ fn recv_impl(
     let mut cmsgspace = vec![0u8; msgspace_size as usize];
 
     let msg = nix_eintr!(recvmsg::<()>(fd, &mut iov, Some(&mut cmsgspace), MSG_FLAGS))?;
+    if msg.flags.contains(MsgFlags::MSG_CTRUNC) {
+        return Err(io::Error::other(
+            "control message truncated",
+        ));
+    }
 
     let mut received_fds = false;
     for cmsg in msg.cmsgs() {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -17,59 +17,50 @@ structural serialization (currently uses msgpack).  This requires the
 use std::cell::RefCell;
 use std::io;
 use std::mem;
-use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
-use std::sync::Mutex;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 
 use serde_::{de, ser};
 use serde_::{de::DeserializeOwned, Deserialize, Serialize};
 
 thread_local! {
-    static IPC_FDS: RefCell<Vec<Vec<RawFd>>> = const {RefCell::new(Vec::new())};
+    // Ser: stack of raw fd accumulator vecs
+    static IPC_SER_FDS: RefCell<Vec<Vec<RawFd>>> = const { RefCell::new(Vec::new()) };
+    // Deser: stack of Option<OwnedFd> vecs being consumed
+    static IPC_DESER_FDS: RefCell<Vec<Vec<Option<OwnedFd>>>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Can transfer a unix file handle across processes.
 ///
-/// The basic requirement is that you have an object that can be converted
-/// into a raw file handle and back.  This for instance is the case for
-/// regular file objects, sockets and many more things.
-///
-/// Once the handle has been serialized the handle no longer lets you
-/// extract the value contained in it.
-///
-/// For customizing the serialization of libraries the
-/// [`HandleRef`](struct.HandleRef.html) object should be used instead.
-pub struct Handle<F>(Mutex<Option<F>>);
+/// The basic requirement is that you have an object that implements
+/// [`AsFd`] (for serialization) and [`From<OwnedFd>`] (for deserialization).
+/// This is the case for regular file objects, sockets, and many more things.
+pub struct Handle<F>(F);
 
 /// A raw reference to a handle.
 ///
 /// This serializes the same way as a `Handle` but only uses a raw
 /// fd to represent it.  Useful to implement custom serializers.
+///
+/// Note: `HandleRef` holds a `RawFd` (not `BorrowedFd`) because it must
+/// be usable in `Send + 'static` message types.  The caller is responsible
+/// for ensuring the fd remains valid for the duration of serialization.
 pub struct HandleRef(pub RawFd);
 
-impl<F: FromRawFd + IntoRawFd> Handle<F> {
+impl<F> Handle<F> {
     /// Wraps the value in a handle.
     pub fn new(f: F) -> Self {
-        f.into()
-    }
-
-    fn extract_raw_fd(&self) -> RawFd {
-        self.0
-            .lock()
-            .unwrap()
-            .take()
-            .map(|x| x.into_raw_fd())
-            .expect("cannot serialize handle twice")
+        Handle(f)
     }
 
     /// Extracts the internal value.
     pub fn into_inner(self) -> F {
-        self.0.lock().unwrap().take().expect("handle was moved")
+        self.0
     }
 }
 
-impl<F: FromRawFd + IntoRawFd> From<F> for Handle<F> {
+impl<F> From<F> for Handle<F> {
     fn from(f: F) -> Self {
-        Handle(Mutex::new(Some(f)))
+        Handle(f)
     }
 }
 
@@ -79,8 +70,7 @@ impl Serialize for HandleRef {
         S: ser::Serializer,
     {
         if is_ipc_mode() {
-            let fd = self.0;
-            let idx = register_fd(fd);
+            let idx = register_fd(self.0);
             idx.serialize(serializer)
         } else {
             Err(ser::Error::custom("can only serialize in ipc mode"))
@@ -88,59 +78,89 @@ impl Serialize for HandleRef {
     }
 }
 
-impl<F: FromRawFd + IntoRawFd> Serialize for Handle<F> {
+impl<F: AsFd> Serialize for Handle<F> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
     {
-        HandleRef(self.extract_raw_fd()).serialize(serializer)
+        if is_ipc_mode() {
+            let raw_fd = self.0.as_fd().as_raw_fd();
+            let idx = register_fd(raw_fd);
+            idx.serialize(serializer)
+        } else {
+            Err(ser::Error::custom("can only serialize in ipc mode"))
+        }
     }
 }
 
-impl<'de, F: FromRawFd + IntoRawFd> Deserialize<'de> for Handle<F> {
+impl<'de, F: From<OwnedFd>> Deserialize<'de> for Handle<F> {
     fn deserialize<D>(deserializer: D) -> Result<Handle<F>, D::Error>
     where
         D: de::Deserializer<'de>,
     {
         if is_ipc_mode() {
             let idx = u32::deserialize(deserializer)?;
-            let fd = lookup_fd(idx).ok_or_else(|| de::Error::custom("fd not found in mapping"))?;
-            unsafe { Ok(Handle(Mutex::new(Some(FromRawFd::from_raw_fd(fd))))) }
+            let owned =
+                lookup_fd(idx).ok_or_else(|| de::Error::custom("fd not found in mapping"))?;
+            Ok(Handle(F::from(owned)))
         } else {
             Err(de::Error::custom("can only deserialize in ipc mode"))
         }
     }
 }
 
-struct ResetIpcSerde;
+struct ResetSerSerde;
 
-impl Drop for ResetIpcSerde {
+impl Drop for ResetSerSerde {
     fn drop(&mut self) {
-        IPC_FDS.with(|x| x.borrow_mut().pop());
+        IPC_SER_FDS.with(|x| x.borrow_mut().pop());
     }
 }
 
-fn enter_ipc_mode<F: FnOnce() -> R, R>(f: F, fds: &mut Vec<RawFd>) -> R {
-    IPC_FDS.with(|x| x.borrow_mut().push(fds.clone()));
-    let reset = ResetIpcSerde;
+struct ResetDeserSerde;
+
+impl Drop for ResetDeserSerde {
+    fn drop(&mut self) {
+        IPC_DESER_FDS.with(|x| x.borrow_mut().pop());
+    }
+}
+
+fn enter_ser_mode<F: FnOnce() -> R, R>(f: F, fds: &mut Vec<RawFd>) -> R {
+    IPC_SER_FDS.with(|x| x.borrow_mut().push(Vec::new()));
+    let reset = ResetSerSerde;
     let rv = f();
-    *fds = IPC_FDS.with(|x| x.borrow_mut().pop()).unwrap_or_default();
+    *fds = IPC_SER_FDS
+        .with(|x| x.borrow_mut().pop())
+        .unwrap_or_default();
     mem::forget(reset);
     rv
 }
 
-fn register_fd(fd: RawFd) -> u32 {
-    IPC_FDS.with(|x| {
+fn enter_deser_mode<F: FnOnce() -> R, R>(f: F, fds: Vec<Option<OwnedFd>>) -> R {
+    IPC_DESER_FDS.with(|x| x.borrow_mut().push(fds));
+    let reset = ResetDeserSerde;
+    let rv = f();
+    // pop drops the vec, auto-closing any remaining (unused) OwnedFds
+    IPC_DESER_FDS.with(|x| x.borrow_mut().pop());
+    mem::forget(reset);
+    rv
+}
+
+fn register_fd(raw_fd: RawFd) -> u32 {
+    IPC_SER_FDS.with(|x| {
         let mut x = x.borrow_mut();
         let fds = x.last_mut().unwrap();
         let rv = fds.len() as u32;
-        fds.push(fd);
+        fds.push(raw_fd);
         rv
     })
 }
 
-fn lookup_fd(idx: u32) -> Option<RawFd> {
-    IPC_FDS.with(|x| x.borrow().last().and_then(|l| l.get(idx as usize).copied()))
+fn lookup_fd(idx: u32) -> Option<OwnedFd> {
+    IPC_DESER_FDS.with(|x| {
+        let mut x = x.borrow_mut();
+        x.last_mut()?.get_mut(idx as usize)?.take()
+    })
 }
 
 /// Checks if serde is in IPC mode.
@@ -148,7 +168,7 @@ fn lookup_fd(idx: u32) -> Option<RawFd> {
 /// This can be used to customize the behavior of serialization/deserialization
 /// implementations for the use with unix-ipc.
 pub fn is_ipc_mode() -> bool {
-    IPC_FDS.with(|x| !x.borrow().is_empty())
+    IPC_SER_FDS.with(|x| !x.borrow().is_empty()) || IPC_DESER_FDS.with(|x| !x.borrow().is_empty())
 }
 
 #[allow(clippy::boxed_local)]
@@ -161,26 +181,40 @@ fn bincode_to_io_error(err: bincode::Error) -> io::Error {
 
 /// Serializes something for IPC communication.
 ///
+/// Takes a reference to keep the source value (and any file handles it contains)
+/// alive until the caller has finished sending.  The returned `BorrowedFd` slice
+/// is tied to the lifetime of `s`: the caller must keep `s` alive until after
+/// the fds have been transmitted via `sendmsg`.
+///
 /// This uses bincode for serialization.  Because UNIX sockets require that
 /// file descriptors are transmitted separately they are accumulated in a
 /// separate buffer.
-pub fn serialize<S: Serialize>(s: S) -> io::Result<(Vec<u8>, Vec<RawFd>)> {
-    let mut fds = Vec::new();
+pub fn serialize<'a, S: Serialize>(s: &'a S) -> io::Result<(Vec<u8>, Vec<BorrowedFd<'a>>)> {
+    let mut raw_fds: Vec<RawFd> = Vec::new();
     let mut out = Vec::new();
-    enter_ipc_mode(|| bincode::serialize_into(&mut out, &s), &mut fds)
+    enter_ser_mode(|| bincode::serialize_into(&mut out, s), &mut raw_fds)
         .map_err(bincode_to_io_error)?;
+    // SAFETY: BorrowedFd<'a> is #[repr(transparent)] over RawFd.  All raw_fds
+    // were obtained via AsFd borrows from *s, so they are valid for 'a.
+    let fds = unsafe {
+        let mut raw_fds = mem::ManuallyDrop::new(raw_fds);
+        Vec::from_raw_parts(
+            raw_fds.as_mut_ptr() as *mut BorrowedFd<'a>,
+            raw_fds.len(),
+            raw_fds.capacity(),
+        )
+    };
     Ok((out, fds))
 }
 
 /// Deserializes something for IPC communication.
 ///
-/// File descriptors need to be provided for deserialization if handleds are
-/// involved.
-pub fn deserialize<D: DeserializeOwned>(bytes: &[u8], fds: &[RawFd]) -> io::Result<D> {
-    let mut fds = fds.to_owned();
-    let result =
-        enter_ipc_mode(|| bincode::deserialize(bytes), &mut fds).map_err(bincode_to_io_error)?;
-    Ok(result)
+/// File descriptors need to be provided for deserialization if handles are
+/// involved.  Ownership of the fds is transferred; any that are not consumed
+/// by deserialization are closed automatically.
+pub fn deserialize<D: DeserializeOwned>(bytes: &[u8], fds: Vec<OwnedFd>) -> io::Result<D> {
+    let slot: Vec<Option<OwnedFd>> = fds.into_iter().map(Some).collect();
+    enter_deser_mode(|| bincode::deserialize(bytes), slot).map_err(bincode_to_io_error)
 }
 
 macro_rules! implement_handle_serialization {
@@ -191,7 +225,7 @@ macro_rules! implement_handle_serialization {
                 S: $crate::_serde_ref::ser::Serializer,
             {
                 $crate::_serde_ref::Serialize::serialize(
-                    &$crate::serde::HandleRef(self.extract_raw_fd()),
+                    &$crate::serde::HandleRef(self.as_raw_fd()),
                     serializer,
                 )
             }
@@ -220,7 +254,7 @@ macro_rules! implement_typed_handle_serialization {
                 S: $crate::_serde_ref::ser::Serializer,
             {
                 $crate::_serde_ref::Serialize::serialize(
-                    &$crate::serde::HandleRef(self.extract_raw_fd()),
+                    &$crate::serde::HandleRef(self.as_raw_fd()),
                     serializer,
                 )
             }
@@ -296,8 +330,13 @@ fn test_basic() {
     use std::io::Read;
     let f = std::fs::File::open("src/serde.rs").unwrap();
     let handle = Handle::from(f);
-    let (bytes, fds) = serialize(handle).unwrap();
-    let f2: Handle<std::fs::File> = deserialize(&bytes, &fds).unwrap();
+    let (bytes, fds) = serialize(&handle).unwrap();
+    // Dup each fd manually to simulate what SCM_RIGHTS does across processes
+    let owned_fds: Vec<OwnedFd> = fds
+        .iter()
+        .map(|f| f.try_clone_to_owned().unwrap())
+        .collect();
+    let f2: Handle<std::fs::File> = deserialize(&bytes, owned_fds).unwrap();
     let mut out = Vec::new();
     f2.into_inner().read_to_end(&mut out).unwrap();
     assert!(out.len() > 100);
@@ -319,11 +358,15 @@ fn test_structural() {
         inner: InnerStruct,
     }
 
-    let (bytes, fds) = serialize(Structural(BadStruct {
+    let (bytes, fds) = serialize(&Structural(BadStruct {
         inner: InnerStruct { value: 42 },
     }))
     .unwrap();
-    let value: Structural<BadStruct> = deserialize(&bytes, &fds).unwrap();
+    let owned_fds: Vec<OwnedFd> = fds
+        .iter()
+        .map(|f| f.try_clone_to_owned().unwrap())
+        .collect();
+    let value: Structural<BadStruct> = deserialize(&bytes, owned_fds).unwrap();
     assert_eq!(
         value.0,
         BadStruct {

--- a/src/typed_channel.rs
+++ b/src/typed_channel.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 
@@ -55,24 +55,20 @@ macro_rules! fd_impl {
                     _marker: std::marker::PhantomData,
                 })
             }
-
-            pub(crate) fn extract_raw_fd(&self) -> RawFd {
-                self.$field.extract_raw_fd()
-            }
         }
 
-        impl<T: Serialize + DeserializeOwned> FromRawFd for $ty {
-            unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        impl<T: Serialize + DeserializeOwned> From<OwnedFd> for $ty {
+            fn from(fd: OwnedFd) -> Self {
                 Self {
-                    $field: FromRawFd::from_raw_fd(fd),
+                    $field: $raw_ty::from(fd),
                     _marker: std::marker::PhantomData,
                 }
             }
         }
 
-        impl<T> IntoRawFd for $ty {
-            fn into_raw_fd(self) -> RawFd {
-                self.$field.into_raw_fd()
+        impl<T> From<$ty> for OwnedFd {
+            fn from(val: $ty) -> OwnedFd {
+                OwnedFd::from(val.$field)
             }
         }
 
@@ -82,6 +78,12 @@ macro_rules! fd_impl {
                     $field: value,
                     _marker: std::marker::PhantomData,
                 }
+            }
+        }
+
+        impl<T> AsFd for $ty {
+            fn as_fd(&self) -> BorrowedFd<'_> {
+                self.$field.as_fd()
             }
         }
 
@@ -135,7 +137,7 @@ impl<T: Serialize + DeserializeOwned> Receiver<T> {
     /// Receives a structured message from the socket.
     pub async fn recv(&self) -> io::Result<T> {
         let (buf, fds) = self.raw_receiver.recv().await?;
-        deserialize::<(T, bool)>(&buf, fds.as_deref().unwrap_or_default()).map(|x| x.0)
+        deserialize::<(T, bool)>(&buf, fds).map(|x| x.0)
     }
 }
 
@@ -148,13 +150,13 @@ impl<T: Serialize + DeserializeOwned> Sender<T> {
         self.raw_sender
     }
 
-    /// Receives a structured message from the socket.
+    /// Sends a structured message from the socket.
     pub async fn send(&self, s: T) -> io::Result<()> {
         // we always serialize a dummy bool at the end so that the message
         // will not be empty because of zero sized types.
-        let (payload, fds) = serialize((s, true))?;
-        self.raw_sender.send(&payload, &fds).await?;
-        Ok(())
+        let to_send = (s, true);
+        let (payload, fds) = serialize(&to_send)?;
+        self.raw_sender.send(&payload, &fds).await.map(|_| ())
     }
 }
 

--- a/tests/test_raw_channel.rs
+++ b/tests/test_raw_channel.rs
@@ -12,7 +12,7 @@ async fn test_basic() {
 
     let (bytes, fds) = rx.recv().await.unwrap();
     assert_eq!(bytes, b"Hello World!");
-    assert_eq!(fds, None);
+    assert!(fds.is_empty());
 }
 
 #[tokio::test]
@@ -31,7 +31,7 @@ async fn test_creds() {
 
     let (bytes, fds, creds) = rx.recv_with_credentials().await.unwrap();
     assert_eq!(bytes, b"Hello World!");
-    assert_eq!(fds, None);
+    assert!(fds.is_empty());
     assert_eq!(creds.uid(), myuid);
     assert_eq!(creds.pid(), mypid);
 }
@@ -52,5 +52,5 @@ async fn test_large_buffer() {
 
     let (bytes, fds) = rx.recv().await.unwrap();
     assert_eq!(bytes, buf.as_bytes());
-    assert_eq!(fds, None);
+    assert!(fds.is_empty());
 }


### PR DESCRIPTION
- Use `AsyncFd<OwnedFd>` in raw receiver/sender to simplify logic
- Serialize via `BorrowedFd`
- Deserialize via `OwnedFd`

Bump Rust version for `BorrowedFd`
Bump crate version due to API changes

Fixes issues #25 and #26

cc @mitsuhiko 